### PR TITLE
python-levenshtein 0.27.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,28 +1,33 @@
 {% set name = "python-levenshtein" %}
 {% set version = "0.27.1" %}
 
+# Note: The project 'python-levenshtein' has been renamed to 'levenshtein'.
+# Since both names are maintained, this has been converted to meta-package
+# which only provides compatibility for using the old name.
+
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
+  # This is a dummy package which only contains metadata (license files, etc.)
+  # and imports 'levenshtein' package of matching version. We'll do the same here.
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
   sha256: 3a5314a011016d373d309a68e875fd029caaa692ad3f32e78319299648045f11
 
 build:
   skip: true  # [py<39]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ stdlib('c') }}
   host:
     - python
     - pip
+    - setuptools
   run:
     - python
+    # We only add the renamed package 'levenshtein' as dependency, where the actual packaging is done
+    - levenshtein =={{ version }}
 
 test:
   imports:
@@ -32,20 +37,16 @@ test:
     - python -c "import sys; from Levenshtein import distance as d; assert 3==d('Good', 'Bad')"
 
 about:
-  home: http://github.com/ztane/python-Levenshtein
+  home: https://github.com/rapidfuzz/python-Levenshtein
   license: GPL-2.0-or-later
   license_family: GPL
   license_file: COPYING
   summary: Python extension for computing string edit distances and similarities.
   description: |
-    A Python extension written in C for fast computation of: Levenshtein (edit)
-    distance and edit sequence manipulation; string similarity; approximate median
-    strings, and generally string averaging; string sequence and set similarity.
-    Levenshtein has a some overlap with difflib (SequenceMatcher). It supports
-    only strings, not arbitrary sequence types, but on the other hand it's much
-    faster.
-  doc_url: https://rawgit.com/ztane/python-Levenshtein/master/docs/Levenshtein.html
-  dev_url: http://github.com/ztane/python-Levenshtein
+    Package has been renamed to 'levenshtein', This package only provides compatibility for old name.
+    Prefer using the renamed package 'levenshtein' directly instead where possible.
+  doc_url: https://github.com/rapidfuzz/python-Levenshtein
+  dev_url: https://github.com/rapidfuzz/python-Levenshtein
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
   sha256: 3a5314a011016d373d309a68e875fd029caaa692ad3f32e78319299648045f11
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "python-levenshtein" %}
 {% set camelName = "python-Levenshtein" %}
-{% set version = "0.12.2" %}
-{% set hash_val = "dc2395fbd148a1ab31090dd113c366695934b9e85fe5a4b2a032745efd0346f6" %}
+{% set version = "0.27.1" %}
+{% set hash_val = "3a5314a011016d373d309a68e875fd029caaa692ad3f32e78319299648045f11" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ camelName }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
   sha256: {{ hash_val }}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 3a5314a011016d373d309a68e875fd029caaa692ad3f32e78319299648045f11
 
 build:
+  skip: true  # [py<39]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,11 +41,12 @@ about:
   license: GPL-2.0-or-later
   license_family: GPL
   license_file: COPYING
-  summary: Python extension for computing string edit distances and similarities.
+  summary: The Levenshtein Python C extension module contains functions for fast computation of Levenshtein distance and string similarity
   description: |
-    Package has been renamed to 'levenshtein', This package only provides compatibility for old name.
+    Package has been renamed to 'levenshtein'. This package only provides compatibility for
+    using the previous name.
     Prefer using the renamed package 'levenshtein' directly instead where possible.
-  doc_url: https://github.com/rapidfuzz/python-Levenshtein
+  doc_url: https://rapidfuzz.github.io/Levenshtein
   dev_url: https://github.com/rapidfuzz/python-Levenshtein
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<39]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,9 @@ requirements:
 test:
   imports:
     - Levenshtein
+  requires:
+    - python
+    - pip
   commands:
     - pip check
     # Trivial test to ensure compiled C code is indeed available

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
   imports:
     - Levenshtein
   commands:
+    - pip check
     # Trivial test to ensure compiled C code is indeed available
     - python -c "import sys; from Levenshtein import distance as d; assert 3==d('Good', 'Bad')"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,6 @@ package:
   version: {{ version }}
 
 source:
-  # This is a dummy package which only contains metadata (license files, etc.)
-  # and imports 'levenshtein' package of matching version. We'll do the same here.
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
   sha256: 3a5314a011016d373d309a68e875fd029caaa692ad3f32e78319299648045f11
 
@@ -26,7 +24,6 @@ requirements:
     - setuptools
   run:
     - python
-    # We only add the renamed package 'levenshtein' as dependency, where the actual packaging is done
     - levenshtein =={{ version }}
 
 test:
@@ -47,9 +44,13 @@ about:
   license_file: COPYING
   summary: The Levenshtein Python C extension module contains functions for fast computation of Levenshtein distance and string similarity
   description: |
-    Package has been renamed to 'levenshtein'. This package only provides compatibility for
-    using the previous name.
-    Prefer using the renamed package 'levenshtein' directly instead where possible.
+    The Levenshtein Python C extension module contains functions for fast computation of:
+      Levenshtein (edit) distance, and edit operations
+      string similarity
+      approximate median strings, and generally string averaging
+      string sequence and set similarity
+      Warining: The package was renamed to 'levenshtein'. 
+      The 'python-levenshtein' package will continue to be updated alongside the new package.
   doc_url: https://rapidfuzz.github.io/Levenshtein
   dev_url: https://github.com/rapidfuzz/python-Levenshtein
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,5 @@
 {% set name = "python-levenshtein" %}
-{% set camelName = "python-Levenshtein" %}
 {% set version = "0.27.1" %}
-{% set hash_val = "3a5314a011016d373d309a68e875fd029caaa692ad3f32e78319299648045f11" %}
 
 package:
   name: {{ name }}
@@ -10,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
-  sha256: {{ hash_val }}
+  sha256: 3a5314a011016d373d309a68e875fd029caaa692ad3f32e78319299648045f11
 
 build:
   number: 0


### PR DESCRIPTION
python-levenshtein 0.27.1 

**Destination channel:** Defaults

### Links

- [PKG-9345]
- dev_url:        https://github.com/rapidfuzz/python-Levenshtein/tree/v0.27.1
- conda_forge:    https://github.com/conda-forge/python-levenshtein-feedstock
- pypi:           https://pypi.org/project/python-levenshtein/0.27.1
- pypi inspector: https://inspector.pypi.io/project/python-levenshtein/0.27.1

### Explanation of changes:

- new version number


[PKG-9345]: https://anaconda.atlassian.net/browse/PKG-9345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ